### PR TITLE
In NPM it is registered as inuit-responsive-widths

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install using Bower:
 
 Install using npm:
 
-    $ npm install --save inuit-widths-responsive
+    $ npm install --save inuit-responsive-widths
 
 
 `widths-responsive` loops through the breakpoints defined in


### PR DESCRIPTION
In npm the package is registered as inuit-responsive-widths, not inuit-widths-responsive.
`$ npm install --save inuit-widths-responsive` therefore throws an error.