### PR TITLE
New breakpoint syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Install using npm:
 `widths-responsive` loops through the breakpoints defined in
 `settings.responsive` to generate prefixed breakpoint-based classes. If you are
 using inuitcss’ default breakpoints, you will be given classes like
-`u-1/4-lap-and-up`, or `u-1-of-2-desk`, etc.
+`u-1/4@lap-and-up`, or `u-1-of-2@desk`, etc.

--- a/_trumps.widths-responsive.scss
+++ b/_trumps.widths-responsive.scss
@@ -19,17 +19,17 @@ $inuit-widths-columns-responsive: (
 // Loop over our breakpoints defined in _settings.responsive.scss
 @each $breakpoint in $breakpoints {
 
-  // Get the name of the breakpoint.
-  $alias: nth($breakpoint, 1);
+    // Get the name of the breakpoint.
+    $alias: nth($breakpoint, 1);
 
-  @include media-query($alias) {
+    @include media-query($alias) {
 
-    // Loop through each of our column sizes and generate its responsive width
-    // classes.
-    @each $inuit-widths-column in $inuit-widths-columns-responsive {
-      @include inuit-widths($inuit-widths-column, \@#{$alias});
+        // Loop through each of our column sizes and generate its responsive width
+        // classes.
+        @each $inuit-widths-column in $inuit-widths-columns-responsive {
+            @include inuit-widths($inuit-widths-column, \@#{$alias});
+        }
+
     }
-
-  }
 
 }

--- a/_trumps.widths-responsive.scss
+++ b/_trumps.widths-responsive.scss
@@ -27,7 +27,7 @@ $inuit-widths-columns-responsive: (
     // Loop through each of our column sizes and generate its responsive width
     // classes.
     @each $inuit-widths-column in $inuit-widths-columns-responsive {
-      @include inuit-widths($inuit-widths-column, -#{$alias});
+      @include inuit-widths($inuit-widths-column, \@#{$alias});
     }
 
   }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "inuit-widths-responsive",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "authors": [
     "Harry Roberts <harry@csswizardry.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inuit-responsive-widths",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Responsively controlled width classes for the inuitcss framework",
   "main": "_trumps.widths-responsive.scss",
   "repository": {


### PR DESCRIPTION
Changing the breakpoints suffix syntax to "_@_desk" etc., according to the discussion in inuitcss/trumps.spacing#8 and the pull-requests for inuitcss/trumps.spacing#9 and inuitcss/trumps.spacing-responsive#14.
