### PR TITLE
Breakpoints are now suffixed to width classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Install using npm:
 
 
 `widths-responsive` loops through the breakpoints defined in
-`settings.responsive` to generate prefixed breakpoint-based classes. If you are
+`settings.responsive` to generate suffixed breakpoint-based classes. If you are
 using inuitcss’ default breakpoints, you will be given classes like
 `u-1/4-lap-and-up`, or `u-1-of-2-desk`, etc.


### PR DESCRIPTION
Update terminology to match new responsive widths class naming.