### PR TITLE
Rename package to align with bower and config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "inuit-responsive-widths",
+  "name": "inuit-widths-responsive",
   "version": "0.2.2",
   "description": "Responsively controlled width classes for the inuitcss framework",
   "main": "_trumps.widths-responsive.scss",


### PR DESCRIPTION
The README file names the package as `inuit-widths-responsive`, as does `bower.json`. This change makes sure that the NPM package definition matches this naming.